### PR TITLE
Install cbindgen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,6 +107,7 @@ run apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y liblzma-
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH=/root/.cargo/bin:$PATH
+RUN cargo install --force cbindgen
 
 USER root
 


### PR DESCRIPTION
Install cbindgen needed to build suricata 6.0.0

Tested and works with the prscript.

NOTE: pcaps buildbot stage fails, due to path issues (can not find cargo) when using sudo. Sudo is also redundant anyways, as commands are run as root.